### PR TITLE
Harden codeQL permissions

### DIFF
--- a/config/workflows/codeql.yml
+++ b/config/workflows/codeql.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: '24 18 * * 3'
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze


### PR DESCRIPTION
Job has already permission set, but better also have an overall permission, in case we had a second job without any permission

Signed-off-by: tobiasKaminsky <tobias@kaminsky.me>