### PR TITLE
Fix pre-commit hook not outputting errors when failing

### DIFF
--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,12 +1,10 @@
 #!/usr/bin/env bash
-set -euo pipefail
-
 function gradle_check() {
     local TASK=$1
     echo "Running check: $TASK..."
     # shellcheck disable=SC2155
     local OUTPUT="/tmp/$TASK-$(date +%s)"
-    ./gradlew "$TASK" > "$OUTPUT" 2>&1
+    ./gradlew "$TASK" &> "$OUTPUT" 
     EXIT_CODE=$?
     if [ $EXIT_CODE -ne 0 ]; then
       cat "$OUTPUT"


### PR DESCRIPTION
Signed-off-by: Álvaro Brey <alvaro.brey@nextcloud.com>
