### PR TITLE
Build: use single ext variable for both kotlin plugins version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,15 @@
+buildscript {
+    ext {
+        daggerVersion = "2.44.2"
+        kotlinVersion = "1.7.22"
+    }
+}
+
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     id 'com.android.library' version '7.3.1' apply false
-    id 'org.jetbrains.kotlin.android' version '1.7.22' apply false
-    id "org.jetbrains.kotlin.kapt" version "1.7.22" apply false
+    id 'org.jetbrains.kotlin.android' version "$kotlinVersion" apply false
+    id "org.jetbrains.kotlin.kapt" version "$kotlinVersion" apply false
     id "com.diffplug.spotless" version "6.12.0" apply false
     id 'io.gitlab.arturbosch.detekt' version '1.22.0' apply false
 }
@@ -30,10 +37,6 @@ task installGitHooks(type: Copy, group: "development") {
 
 allprojects {
     group = 'com.nextcloud.android-common'
-}
-
-ext {
-    daggerVersion = "2.44.2"
 }
 
 subprojects {


### PR DESCRIPTION
Avoids duplicate PRs and inconsistency.

The existing PRS may need to be recreated or closed
