### PR TITLE
ui: Utilities to color with unchanged primary color as background

### DIFF
--- a/ui/src/main/java/com/nextcloud/android/common/ui/theme/MaterialSchemes.kt
+++ b/ui/src/main/java/com/nextcloud/android/common/ui/theme/MaterialSchemes.kt
@@ -38,5 +38,13 @@ interface MaterialSchemes {
     companion object {
         fun fromServerTheme(theme: ServerTheme): MaterialSchemes = MaterialSchemesImpl(theme)
         fun fromColor(@ColorInt color: Int): MaterialSchemes = MaterialSchemesImpl(color)
+
+        /**
+         * Creates a [MaterialSchemes] where the primary color is preserved as-is. This is useful for views where
+         * we want it for branding purposes, especially as a background color. The resulting dark and light
+         * schemes will be the same, as they are derived from the primary color and not the device theme.
+         */
+        fun withPrimaryAsBackground(@ColorInt primary: Int): MaterialSchemes =
+            MaterialSchemesImpl(primary, true)
     }
 }

--- a/ui/src/main/java/com/nextcloud/android/common/ui/theme/MaterialSchemesImpl.kt
+++ b/ui/src/main/java/com/nextcloud/android/common/ui/theme/MaterialSchemesImpl.kt
@@ -22,6 +22,7 @@
 package com.nextcloud.android.common.ui.theme
 
 import androidx.annotation.ColorInt
+import hct.Hct
 import scheme.Scheme
 
 internal class MaterialSchemesImpl :
@@ -29,10 +30,32 @@ internal class MaterialSchemesImpl :
     override val lightScheme: Scheme
     override val darkScheme: Scheme
 
-    constructor(@ColorInt primaryColor: Int) {
-        lightScheme = Scheme.light(primaryColor)
-        darkScheme = Scheme.dark(primaryColor)
+    constructor(@ColorInt primaryColor: Int, primaryAsBackground: Boolean = false) {
+        if (primaryAsBackground) {
+            val scheme = primaryAsBackgroundScheme(primaryColor)
+            darkScheme = scheme
+            lightScheme = scheme
+        } else {
+            lightScheme = Scheme.light(primaryColor)
+            darkScheme = Scheme.dark(primaryColor)
+        }
+    }
+
+    private fun primaryAsBackgroundScheme(primaryColor: Int): Scheme {
+        val hct = Hct.fromInt(primaryColor)
+        val isDark = hct.tone < DARK_TONE_THRESHOLD
+        val scheme = if (isDark) {
+            Scheme.lightContent(primaryColor).withPrimary(primaryColor)
+        } else {
+            Scheme.darkContent(primaryColor).withPrimary(primaryColor)
+        }
+        return scheme
     }
 
     constructor(serverTheme: ServerTheme) : this(serverTheme.primaryColor)
+
+    companion object {
+        // chosen from material-color-utils default tone for dark backgrounds
+        private const val DARK_TONE_THRESHOLD = 80.0
+    }
 }

--- a/ui/src/main/java/com/nextcloud/android/common/ui/theme/utils/AndroidViewThemeUtils.kt
+++ b/ui/src/main/java/com/nextcloud/android/common/ui/theme/utils/AndroidViewThemeUtils.kt
@@ -32,6 +32,7 @@ import android.graphics.PorterDuff
 import android.graphics.Typeface
 import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Drawable
+import android.os.Build
 import android.text.Spannable
 import android.text.SpannableString
 import android.text.style.ForegroundColorSpan
@@ -218,8 +219,12 @@ class AndroidViewThemeUtils @Inject constructor(schemes: MaterialSchemes, privat
     }
 
     fun themeStatusBar(activity: Activity) {
+        themeStatusBar(activity, ColorRole.SURFACE)
+    }
+
+    fun themeStatusBar(activity: Activity, colorRole: ColorRole) {
         withScheme(activity) { scheme ->
-            colorStatusBar(activity, scheme.surface)
+            colorStatusBar(activity, colorRole.select(scheme))
         }
     }
 
@@ -371,9 +376,17 @@ class AndroidViewThemeUtils @Inject constructor(schemes: MaterialSchemes, privat
     /**
      * Tints the image with element color
      */
+    @Deprecated(
+        replaceWith = ReplaceWith("colorImageView(imageView, ColorRole.PRIMARY)"),
+        message = "Use colorImageView(imageView, ColorRole.PRIMARY) instead"
+    )
     fun colorImageView(imageView: ImageView) {
+        colorImageView(imageView, ColorRole.PRIMARY)
+    }
+
+    fun colorImageView(imageView: ImageView, colorRole: ColorRole) {
         withScheme(imageView) { scheme ->
-            imageView.imageTintList = ColorStateList.valueOf(scheme.primary)
+            imageView.imageTintList = ColorStateList.valueOf(colorRole.select(scheme))
         }
     }
 
@@ -402,21 +415,42 @@ class AndroidViewThemeUtils @Inject constructor(schemes: MaterialSchemes, privat
         }
     }
 
+    @Deprecated(
+        replaceWith = ReplaceWith(
+            "colorCircularProgressBar(progressBar, ColorRole.ON_PRIMARY_CONTAINER)",
+            imports = ["com.nextcloud.android.common.ui.theme.utils.ColorRole"]
+        ),
+        message = "Use colorCircularProgressBar(progressBar, ColorRole.ON_PRIMARY_CONTAINER) instead"
+    )
     fun colorCircularProgressBarOnPrimaryContainer(progressBar: ProgressBar) {
-        withScheme(progressBar) { scheme ->
-            progressBar.indeterminateDrawable.setColorFilter(scheme.onPrimaryContainer, PorterDuff.Mode.SRC_ATOP)
-        }
+        colorCircularProgressBar(progressBar, ColorRole.ON_PRIMARY_CONTAINER)
     }
 
+    @Deprecated(
+        replaceWith = ReplaceWith(
+            "colorCircularProgressBar(progressBar, ColorRole.PRIMARY)",
+            imports = ["com.nextcloud.android.common.ui.theme.utils.ColorRole"]
+        ),
+        message = "Use colorCircularProgressBar(progressBar, ColorRole.PRIMARY) instead"
+    )
     fun colorCircularProgressBar(progressBar: ProgressBar) {
-        withScheme(progressBar) { scheme ->
-            progressBar.indeterminateDrawable.setColorFilter(scheme.primary, PorterDuff.Mode.SRC_ATOP)
-        }
+        colorCircularProgressBar(progressBar, ColorRole.PRIMARY)
     }
 
+    @Deprecated(
+        replaceWith = ReplaceWith(
+            "colorCircularProgressBar(progressBar, ColorRole.ON_SURFACE_VARIANT)",
+            imports = ["com.nextcloud.android.common.ui.theme.utils.ColorRole"]
+        ),
+        message = "Use colorCircularProgressBar(progressBar, ColorRole.ON_SURFACE_VARIANT) instead"
+    )
     fun colorCircularProgressBarOnSurfaceVariant(progressBar: ProgressBar) {
+        colorCircularProgressBar(progressBar, ColorRole.ON_SURFACE_VARIANT)
+    }
+
+    fun colorCircularProgressBar(progressBar: ProgressBar, colorRole: ColorRole) {
         withScheme(progressBar) { scheme ->
-            progressBar.indeterminateDrawable.setColorFilter(scheme.onSurfaceVariant, PorterDuff.Mode.SRC_ATOP)
+            progressBar.indeterminateDrawable.setColorFilter(colorRole.select(scheme), PorterDuff.Mode.SRC_ATOP)
         }
     }
 
@@ -467,6 +501,19 @@ class AndroidViewThemeUtils @Inject constructor(schemes: MaterialSchemes, privat
 
             editText.setHintTextColor(scheme.onSurfaceVariant)
             editText.setTextColor(scheme.onSurface)
+        }
+    }
+
+    fun colorEditTextOnPrimary(editText: EditText) {
+        withScheme(editText) { scheme ->
+            // TODO check API-level compatibility
+            editText.setHintTextColor(scheme.onPrimary)
+            editText.setTextColor(scheme.onPrimary)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                editText.textCursorDrawable?.let {
+                    editText.textCursorDrawable = colorDrawable(it, scheme.onPrimary)
+                }
+            }
         }
     }
 

--- a/ui/src/main/java/com/nextcloud/android/common/ui/theme/utils/ColorRole.kt
+++ b/ui/src/main/java/com/nextcloud/android/common/ui/theme/utils/ColorRole.kt
@@ -31,6 +31,9 @@ enum class ColorRole(internal val select: (Scheme) -> Int) {
     ON_PRIMARY({ it.onPrimary }),
     ON_SECONDARY_CONTAINER({ it.onSecondaryContainer }),
     ON_SURFACE({ it.onSurface }),
+    ON_SURFACE_VARIANT({ it.onSurfaceVariant }),
     PRIMARY({ it.primary }),
+    PRIMARY_CONTAINER({ it.primaryContainer }),
+    ON_PRIMARY_CONTAINER({ it.onPrimaryContainer }),
     SURFACE({ it.surface })
 }

--- a/ui/src/main/java/com/nextcloud/android/common/ui/theme/utils/MaterialViewThemeUtils.kt
+++ b/ui/src/main/java/com/nextcloud/android/common/ui/theme/utils/MaterialViewThemeUtils.kt
@@ -308,6 +308,32 @@ class MaterialViewThemeUtils @Inject constructor(schemes: MaterialSchemes, priva
         }
     }
 
+    fun colorTextInputLayout(textInputLayout: TextInputLayout, colorRole: ColorRole) {
+        withScheme(textInputLayout) { scheme ->
+            val errorColor = scheme.error
+
+            val errorColorStateList = buildColorStateList(
+                -android.R.attr.state_focused to errorColor,
+                android.R.attr.state_focused to errorColor
+            )
+
+            val coloredColorStateList = buildColorStateList(
+                -android.R.attr.state_focused to scheme.outline,
+                android.R.attr.state_focused to colorRole.select(scheme)
+            )
+
+            textInputLayout.setBoxStrokeColorStateList(coloredColorStateList)
+            textInputLayout.setErrorIconTintList(errorColorStateList)
+            textInputLayout.setErrorTextColor(errorColorStateList)
+            textInputLayout.boxStrokeErrorColor = errorColorStateList
+            textInputLayout.defaultHintTextColor = coloredColorStateList
+
+            textInputLayout.editText?.highlightColor = colorRole.select(scheme)
+            textInputLayout.setEndIconTintList(coloredColorStateList)
+            textInputLayout.setStartIconTintList(coloredColorStateList)
+        }
+    }
+
     fun themeTabLayout(tabLayout: TabLayout) {
         withScheme(tabLayout) { scheme ->
             colorTabLayout(tabLayout, scheme)


### PR DESCRIPTION
Intended to fix login screens with too light colors. This introduces a special `MaterialSchemes` in which light and dark theme are the same, and are calculated based on the primary color tone. The unchanged primary color is then set as `primary` for that scheme.


Signed-off-by: Álvaro Brey <alvaro.brey@nextcloud.com>
