### PR TITLE
Add jitpack.yml to specify Java 11

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk11


### PR DESCRIPTION
We need java 11 for build now, and jitpack uses 8 by default

Signed-off-by: Álvaro Brey <alvaro.brey@nextcloud.com>
