### PR TITLE
feat(theming): Add support for ExtendedFloatingActionButton (#67)

### DIFF
--- a/ui/src/main/java/com/nextcloud/android/common/ui/theme/utils/MaterialViewThemeUtils.kt
+++ b/ui/src/main/java/com/nextcloud/android/common/ui/theme/utils/MaterialViewThemeUtils.kt
@@ -34,6 +34,7 @@ import com.google.android.material.button.MaterialButton
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.chip.Chip
 import com.google.android.material.chip.ChipDrawable
+import com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.google.android.material.progressindicator.LinearProgressIndicator
 import com.google.android.material.snackbar.Snackbar
@@ -74,6 +75,20 @@ class MaterialViewThemeUtils @Inject constructor(schemes: MaterialSchemes, priva
             )
 
             fab.imageTintList = buildColorStateList(
+                android.R.attr.state_enabled to scheme.onPrimaryContainer,
+                -android.R.attr.state_enabled to Color.WHITE
+            )
+        }
+    }
+
+    fun themeExtendedFAB(fab: ExtendedFloatingActionButton) {
+        withScheme(fab) { scheme ->
+            fab.backgroundTintList = buildColorStateList(
+                android.R.attr.state_enabled to scheme.primaryContainer,
+                -android.R.attr.state_enabled to Color.GRAY
+            )
+
+            fab.iconTint = buildColorStateList(
                 android.R.attr.state_enabled to scheme.onPrimaryContainer,
                 -android.R.attr.state_enabled to Color.WHITE
             )

--- a/ui/src/main/java/com/nextcloud/android/common/ui/theme/utils/MaterialViewThemeUtils.kt
+++ b/ui/src/main/java/com/nextcloud/android/common/ui/theme/utils/MaterialViewThemeUtils.kt
@@ -88,10 +88,12 @@ class MaterialViewThemeUtils @Inject constructor(schemes: MaterialSchemes, priva
                 -android.R.attr.state_enabled to Color.GRAY
             )
 
-            fab.iconTint = buildColorStateList(
+            val colorStateList = buildColorStateList(
                 android.R.attr.state_enabled to scheme.onPrimaryContainer,
                 -android.R.attr.state_enabled to Color.WHITE
             )
+            fab.setTextColor(colorStateList)
+            fab.iconTint = colorStateList
         }
     }
 


### PR DESCRIPTION
# :eye:  Samples

Base | Light | Dark
--- | --- | ---
`#0082c9` (Nextcloud default brand) | ![image](https://user-images.githubusercontent.com/4741199/218252728-77142425-9215-43d0-8485-0a30de969515.png) | ![image](https://user-images.githubusercontent.com/4741199/218252709-669139ad-56ae-439f-a044-062982c9abf8.png)
`#bf678b` | ![image](https://user-images.githubusercontent.com/4741199/218252681-295788b4-4222-404a-ae02-c65d4b70d980.png) | ![image](https://user-images.githubusercontent.com/4741199/218252700-25c248be-3dee-4cdb-9af1-f51048400975.png)
`#a5b872` | ![image](https://user-images.githubusercontent.com/4741199/218252764-8999d566-16c6-4a50-97ce-05f6fbd5f4e6.png) | ![image](https://user-images.githubusercontent.com/4741199/218252776-3abd90fa-9581-4c41-9930-ab713c2d4cfc.png)
`#6ea68f` | ![image](https://user-images.githubusercontent.com/4741199/218252814-187fd063-ccb1-4739-93c7-1af8c9254e6c.png) | ![image](https://user-images.githubusercontent.com/4741199/218252802-837bbe0e-f78b-4d17-805b-af58140732ea.png)
