### PR TITLE
Fix toolbar trailing icon tinting

### DIFF
--- a/ui/src/main/java/com/nextcloud/android/common/ui/theme/utils/AndroidViewThemeUtils.kt
+++ b/ui/src/main/java/com/nextcloud/android/common/ui/theme/utils/AndroidViewThemeUtils.kt
@@ -133,7 +133,7 @@ class AndroidViewThemeUtils @Inject constructor(schemes: MaterialSchemes, privat
 
     fun colorToolbarMenuIcon(context: Context, item: MenuItem) {
         withScheme(context) { scheme ->
-            colorMenuItemIcon(scheme.onSurface, item)
+            colorMenuItemIcon(scheme.onSurfaceVariant, item)
         }
     }
 

--- a/ui/src/main/java/com/nextcloud/android/common/ui/theme/utils/AndroidViewThemeUtils.kt
+++ b/ui/src/main/java/com/nextcloud/android/common/ui/theme/utils/AndroidViewThemeUtils.kt
@@ -144,10 +144,7 @@ class AndroidViewThemeUtils @Inject constructor(schemes: MaterialSchemes, privat
     }
 
     private fun colorMenuItemIcon(@ColorInt color: Int, item: MenuItem) {
-        val normalDrawable = item.icon
-        val wrapDrawable = DrawableCompat.wrap(normalDrawable)
-        DrawableCompat.setTint(wrapDrawable, color)
-        item.icon = wrapDrawable
+        item.icon.setTint(color)
     }
 
     private fun colorMenuItemText(@ColorInt color: Int, item: MenuItem) {

--- a/ui/src/main/java/com/nextcloud/android/common/ui/theme/utils/MaterialViewThemeUtils.kt
+++ b/ui/src/main/java/com/nextcloud/android/common/ui/theme/utils/MaterialViewThemeUtils.kt
@@ -57,7 +57,7 @@ class MaterialViewThemeUtils @Inject constructor(schemes: MaterialSchemes, priva
     ViewThemeUtilsBase(schemes) {
     fun colorToolbarOverflowIcon(toolbar: MaterialToolbar) {
         withScheme(toolbar) { scheme ->
-            toolbar.overflowIcon?.setColorFilter(scheme.onSurface, PorterDuff.Mode.SRC_ATOP)
+            toolbar.overflowIcon?.setColorFilter(scheme.onSurfaceVariant, PorterDuff.Mode.SRC_ATOP)
         }
     }
 


### PR DESCRIPTION
latest appcompat and material implementations seemed to have changed to icons need to be tinted directly and not via a wrapped drawable. Furthermore according to M3 the trailing icons are to be colored `onSurfaceVariant`.