### PR TITLE
Add SPDX header to material implementation classes

### DIFF
--- a/.idea/codeStyles/Project.xml.license
+++ b/.idea/codeStyles/Project.xml.license
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2022-2024 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: MIT

--- a/.idea/codeStyles/codeStyleConfig.xml.license
+++ b/.idea/codeStyles/codeStyleConfig.xml.license
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2022-2024 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: MIT

--- a/.idea/copyright/profiles_settings.xml.license
+++ b/.idea/copyright/profiles_settings.xml.license
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2022-2024 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: MIT

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -3,14 +3,10 @@ Upstream-Name: android-common
 Upstream-Contact: Nextcloud Android team <android@nextcloud.com>
 Source: https://github.com/nextcloud/android-common
 
-Files: material-color-utilities/*
-Copyright: 2022 Google LLC
-License: Apache-2.0
-
 Files: gradlew gradlew.bat gradle/wrapper/gradle-wrapper.jar
 Copyright: 2015-2021 the original authors
 License: Apache-2.0
 
-Files: gradle/verification-keyring.keys gradle/verification-metadata.xml renovate.json5 */.gitignore .idea/*
+Files: gradle/verification-keyring.keys gradle/verification-metadata.xml renovate.json5 */.gitignore .idea/codeStyles/* .idea/copyright/profiles_settings.xml
 Copyright: none
 License: MIT

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -2,11 +2,3 @@ Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: android-common
 Upstream-Contact: Nextcloud Android team <android@nextcloud.com>
 Source: https://github.com/nextcloud/android-common
-
-Files: gradlew gradlew.bat gradle/wrapper/gradle-wrapper.jar
-Copyright: 2015-2021 the original authors
-License: Apache-2.0
-
-Files: gradle/verification-keyring.keys gradle/verification-metadata.xml renovate.json5 */.gitignore .idea/codeStyles/* .idea/copyright/profiles_settings.xml
-Copyright: none
-License: MIT

--- a/core/.gitignore
+++ b/core/.gitignore
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2022-2023 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: MIT
+
 /build

--- a/gradle/verification-keyring.keys.license
+++ b/gradle/verification-keyring.keys.license
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: MIT

--- a/gradle/verification-keyring.license
+++ b/gradle/verification-keyring.license
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: MIT

--- a/gradle/verification-metadata.xml.license
+++ b/gradle/verification-metadata.xml.license
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: MIT

--- a/gradle/wrapper/gradle-wrapper.jar.license
+++ b/gradle/wrapper/gradle-wrapper.jar.license
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2015-2021 the original authors
+# SPDX-License-Identifier: Apache-2.0

--- a/gradlew
+++ b/gradlew
@@ -1,6 +1,9 @@
 #!/bin/sh
 
 #
+# SPDX-FileCopyrightText: 2015-2021 the original author or authors.
+# SPDX-License-Identifier: Apache-2.0
+#
 # Copyright © 2015-2021 the original authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -1,4 +1,7 @@
 @rem
+@rem SPDX-FileCopyrightText: 2015 the original author or authors.
+@rem SPDX-License-Identifier: Apache-2.0
+@rem
 @rem Copyright 2015 the original author or authors.
 @rem
 @rem Licensed under the Apache License, Version 2.0 (the "License");
@@ -43,11 +46,11 @@ set JAVA_EXE=java.exe
 %JAVA_EXE% -version >NUL 2>&1
 if %ERRORLEVEL% equ 0 goto execute
 
-echo.
-echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
-echo.
-echo Please set the JAVA_HOME variable in your environment to match the
-echo location of your Java installation.
+echo. 1>&2
+echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH. 1>&2
+echo. 1>&2
+echo Please set the JAVA_HOME variable in your environment to match the 1>&2
+echo location of your Java installation. 1>&2
 
 goto fail
 
@@ -57,11 +60,11 @@ set JAVA_EXE=%JAVA_HOME%/bin/java.exe
 
 if exist "%JAVA_EXE%" goto execute
 
-echo.
-echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
-echo.
-echo Please set the JAVA_HOME variable in your environment to match the
-echo location of your Java installation.
+echo. 1>&2
+echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME% 1>&2
+echo. 1>&2
+echo Please set the JAVA_HOME variable in your environment to match the 1>&2
+echo location of your Java installation. 1>&2
 
 goto fail
 

--- a/material-color-utilities/.gitignore
+++ b/material-color-utilities/.gitignore
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2022-2024 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: MIT
+
 /build

--- a/material-color-utilities/README.txt
+++ b/material-color-utilities/README.txt
@@ -1,2 +1,5 @@
+SPDX-FileCopyrightText: 2022-2024 Nextcloud GmbH and Nextcloud contributors
+SPDX-License-Identifier: MIT
+
 Imported from https://github.com/material-foundation/material-color-utilities with license APACHE-2.0,to be substituted
 with a Gradle dependency when they publish it.

--- a/material-color-utilities/src/main/java/blend/Blend.java
+++ b/material-color-utilities/src/main/java/blend/Blend.java
@@ -1,4 +1,8 @@
 /*
+ * SPDX-FileCopyrightText: 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
  * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/material-color-utilities/src/main/java/contrast/Contrast.java
+++ b/material-color-utilities/src/main/java/contrast/Contrast.java
@@ -1,5 +1,9 @@
 /*
- * Copyright 2022 Google LLC
+ * SPDX-FileCopyrightText: 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/material-color-utilities/src/main/java/dislike/DislikeAnalyzer.java
+++ b/material-color-utilities/src/main/java/dislike/DislikeAnalyzer.java
@@ -1,5 +1,9 @@
 /*
- * Copyright 2022 Google LLC
+ * SPDX-FileCopyrightText: 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/material-color-utilities/src/main/java/dynamiccolor/ContrastCurve.java
+++ b/material-color-utilities/src/main/java/dynamiccolor/ContrastCurve.java
@@ -1,5 +1,9 @@
 /*
- * Copyright 2023 Google LLC
+ * SPDX-FileCopyrightText: 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/material-color-utilities/src/main/java/dynamiccolor/DynamicColor.java
+++ b/material-color-utilities/src/main/java/dynamiccolor/DynamicColor.java
@@ -1,4 +1,8 @@
 /*
+ * SPDX-FileCopyrightText: 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
  * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/material-color-utilities/src/main/java/dynamiccolor/MaterialDynamicColors.java
+++ b/material-color-utilities/src/main/java/dynamiccolor/MaterialDynamicColors.java
@@ -1,5 +1,9 @@
 /*
- * Copyright 2023 Google LLC
+ * SPDX-FileCopyrightText: 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/material-color-utilities/src/main/java/dynamiccolor/ToneDeltaPair.java
+++ b/material-color-utilities/src/main/java/dynamiccolor/ToneDeltaPair.java
@@ -1,4 +1,8 @@
 /*
+ * SPDX-FileCopyrightText: 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
  * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/material-color-utilities/src/main/java/dynamiccolor/TonePolarity.java
+++ b/material-color-utilities/src/main/java/dynamiccolor/TonePolarity.java
@@ -1,4 +1,8 @@
 /*
+ * SPDX-FileCopyrightText: 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
  * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/material-color-utilities/src/main/java/hct/Cam16.java
+++ b/material-color-utilities/src/main/java/hct/Cam16.java
@@ -1,4 +1,8 @@
 /*
+ * SPDX-FileCopyrightText: 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
  * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/material-color-utilities/src/main/java/hct/Hct.java
+++ b/material-color-utilities/src/main/java/hct/Hct.java
@@ -1,4 +1,8 @@
 /*
+ * SPDX-FileCopyrightText: 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
  * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/material-color-utilities/src/main/java/hct/HctSolver.java
+++ b/material-color-utilities/src/main/java/hct/HctSolver.java
@@ -1,4 +1,8 @@
 /*
+ * SPDX-FileCopyrightText: 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
  * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/material-color-utilities/src/main/java/hct/ViewingConditions.java
+++ b/material-color-utilities/src/main/java/hct/ViewingConditions.java
@@ -1,4 +1,8 @@
 /*
+ * SPDX-FileCopyrightText: 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
  * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/material-color-utilities/src/main/java/palettes/CorePalette.java
+++ b/material-color-utilities/src/main/java/palettes/CorePalette.java
@@ -1,4 +1,8 @@
 /*
+ * SPDX-FileCopyrightText: 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
  * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/material-color-utilities/src/main/java/palettes/TonalPalette.java
+++ b/material-color-utilities/src/main/java/palettes/TonalPalette.java
@@ -1,4 +1,8 @@
 /*
+ * SPDX-FileCopyrightText: 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
  * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/material-color-utilities/src/main/java/quantize/PointProvider.java
+++ b/material-color-utilities/src/main/java/quantize/PointProvider.java
@@ -1,4 +1,8 @@
 /*
+ * SPDX-FileCopyrightText: 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
  * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/material-color-utilities/src/main/java/quantize/PointProviderLab.java
+++ b/material-color-utilities/src/main/java/quantize/PointProviderLab.java
@@ -1,4 +1,8 @@
 /*
+ * SPDX-FileCopyrightText: 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
  * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/material-color-utilities/src/main/java/quantize/Quantizer.java
+++ b/material-color-utilities/src/main/java/quantize/Quantizer.java
@@ -1,4 +1,8 @@
 /*
+ * SPDX-FileCopyrightText: 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
  * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/material-color-utilities/src/main/java/quantize/QuantizerCelebi.java
+++ b/material-color-utilities/src/main/java/quantize/QuantizerCelebi.java
@@ -1,4 +1,8 @@
 /*
+ * SPDX-FileCopyrightText: 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
  * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/material-color-utilities/src/main/java/quantize/QuantizerMap.java
+++ b/material-color-utilities/src/main/java/quantize/QuantizerMap.java
@@ -1,4 +1,8 @@
 /*
+ * SPDX-FileCopyrightText: 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
  * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/material-color-utilities/src/main/java/quantize/QuantizerResult.java
+++ b/material-color-utilities/src/main/java/quantize/QuantizerResult.java
@@ -1,4 +1,8 @@
 /*
+ * SPDX-FileCopyrightText: 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
  * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/material-color-utilities/src/main/java/quantize/QuantizerWsmeans.java
+++ b/material-color-utilities/src/main/java/quantize/QuantizerWsmeans.java
@@ -1,4 +1,8 @@
 /*
+ * SPDX-FileCopyrightText: 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
  * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/material-color-utilities/src/main/java/quantize/QuantizerWu.java
+++ b/material-color-utilities/src/main/java/quantize/QuantizerWu.java
@@ -1,4 +1,8 @@
 /*
+ * SPDX-FileCopyrightText: 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
  * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/material-color-utilities/src/main/java/scheme/DynamicScheme.java
+++ b/material-color-utilities/src/main/java/scheme/DynamicScheme.java
@@ -1,4 +1,8 @@
 /*
+ * SPDX-FileCopyrightText: 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
  * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/material-color-utilities/src/main/java/scheme/Scheme.java
+++ b/material-color-utilities/src/main/java/scheme/Scheme.java
@@ -1,4 +1,8 @@
 /*
+ * SPDX-FileCopyrightText: 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
  * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/material-color-utilities/src/main/java/scheme/SchemeContent.java
+++ b/material-color-utilities/src/main/java/scheme/SchemeContent.java
@@ -1,4 +1,8 @@
 /*
+ * SPDX-FileCopyrightText: 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
  * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/material-color-utilities/src/main/java/scheme/SchemeExpressive.java
+++ b/material-color-utilities/src/main/java/scheme/SchemeExpressive.java
@@ -1,4 +1,8 @@
 /*
+ * SPDX-FileCopyrightText: 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
  * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/material-color-utilities/src/main/java/scheme/SchemeFidelity.java
+++ b/material-color-utilities/src/main/java/scheme/SchemeFidelity.java
@@ -1,5 +1,9 @@
 /*
- * Copyright 2022 Google LLC
+ * SPDX-FileCopyrightText: 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/material-color-utilities/src/main/java/scheme/SchemeFruitSalad.java
+++ b/material-color-utilities/src/main/java/scheme/SchemeFruitSalad.java
@@ -1,4 +1,8 @@
 /*
+ * SPDX-FileCopyrightText: 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
  * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/material-color-utilities/src/main/java/scheme/SchemeMonochrome.java
+++ b/material-color-utilities/src/main/java/scheme/SchemeMonochrome.java
@@ -1,4 +1,8 @@
 /*
+ * SPDX-FileCopyrightText: 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
  * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/material-color-utilities/src/main/java/scheme/SchemeNeutral.java
+++ b/material-color-utilities/src/main/java/scheme/SchemeNeutral.java
@@ -1,5 +1,9 @@
 /*
- * Copyright 2022 Google LLC
+ * SPDX-FileCopyrightText: 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/material-color-utilities/src/main/java/scheme/SchemeRainbow.java
+++ b/material-color-utilities/src/main/java/scheme/SchemeRainbow.java
@@ -1,5 +1,9 @@
 /*
- * Copyright 2023 Google LLC
+ * SPDX-FileCopyrightText: 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/material-color-utilities/src/main/java/scheme/SchemeTonalSpot.java
+++ b/material-color-utilities/src/main/java/scheme/SchemeTonalSpot.java
@@ -1,5 +1,9 @@
 /*
- * Copyright 2022 Google LLC
+ * SPDX-FileCopyrightText: 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/material-color-utilities/src/main/java/scheme/SchemeVibrant.java
+++ b/material-color-utilities/src/main/java/scheme/SchemeVibrant.java
@@ -1,5 +1,9 @@
 /*
- * Copyright 2022 Google LLC
+ * SPDX-FileCopyrightText: 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/material-color-utilities/src/main/java/scheme/Variant.java
+++ b/material-color-utilities/src/main/java/scheme/Variant.java
@@ -1,5 +1,9 @@
 /*
- * Copyright 2022 Google LLC
+ * SPDX-FileCopyrightText: 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/material-color-utilities/src/main/java/score/Score.java
+++ b/material-color-utilities/src/main/java/score/Score.java
@@ -1,4 +1,8 @@
 /*
+ * SPDX-FileCopyrightText: 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
  * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/material-color-utilities/src/main/java/temperature/TemperatureCache.java
+++ b/material-color-utilities/src/main/java/temperature/TemperatureCache.java
@@ -1,5 +1,9 @@
 /*
- * Copyright 2022 Google LLC
+ * SPDX-FileCopyrightText: 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/material-color-utilities/src/main/java/utils/ColorUtils.java
+++ b/material-color-utilities/src/main/java/utils/ColorUtils.java
@@ -1,4 +1,8 @@
 /*
+ * SPDX-FileCopyrightText: 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
  * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/material-color-utilities/src/main/java/utils/MathUtils.java
+++ b/material-color-utilities/src/main/java/utils/MathUtils.java
@@ -1,4 +1,8 @@
 /*
+ * SPDX-FileCopyrightText: 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
  * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/material-color-utilities/src/main/java/utils/StringUtils.java
+++ b/material-color-utilities/src/main/java/utils/StringUtils.java
@@ -1,4 +1,8 @@
 /*
+ * SPDX-FileCopyrightText: 2021 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/*
  * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/renovate.json5.license
+++ b/renovate.json5.license
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: MIT

--- a/sample/.gitignore
+++ b/sample/.gitignore
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2022-2023 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: MIT
+
 /build

--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2022-2023 Nextcloud GmbH and Nextcloud contributors
+# SPDX-License-Identifier: MIT
+
 /build


### PR DESCRIPTION
...to remove duplicated deprecation warning from reuse linter, i.e.

> /opt/venv/lib/python3.11/site-packages/reuse/project.py:286: PendingDeprecationWarning: Copyright and licensing information for '.idea/copyright/Nextcloud_Android_Common_Library.xml' has been found in both '.idea/copyright/Nextcloud_Android_Common_Library.xml' and in the DEP5 file located at '.reuse/dep5'. The information for these two sources has been aggregated. In the future this behaviour will change, and you will need to explicitly enable aggregation. See <https://github.com/fsfe/reuse-tool/issues/779>. You need do nothing yet. Run with `--suppress-deprecation` to hide this warning.
  warnings.warn(
