### PR TITLE
BugFix - Add IME Inset

### DIFF
--- a/ui/src/main/java/com/nextcloud/android/common/ui/util/extensions/AppCompatActivityExtensions.kt
+++ b/ui/src/main/java/com/nextcloud/android/common/ui/util/extensions/AppCompatActivityExtensions.kt
@@ -17,7 +17,7 @@ import androidx.appcompat.app.AppCompatActivity
 
 @JvmOverloads
 @Suppress("MagicNumber")
-fun AppCompatActivity.prepareWindowForEdgeToEdge(
+fun AppCompatActivity.applyEdgeToEdgeWithSystemBarPadding(
     statusBarStyle: SystemBarStyle = SystemBarStyle.auto(Color.TRANSPARENT, Color.TRANSPARENT),
     navigationBarStyle: SystemBarStyle = SystemBarStyle.auto(Color.TRANSPARENT, Color.TRANSPARENT)
 ) {

--- a/ui/src/main/java/com/nextcloud/android/common/ui/util/extensions/AppCompatActivityExtensions.kt
+++ b/ui/src/main/java/com/nextcloud/android/common/ui/util/extensions/AppCompatActivityExtensions.kt
@@ -17,7 +17,7 @@ import androidx.appcompat.app.AppCompatActivity
 
 @JvmOverloads
 @Suppress("MagicNumber")
-fun AppCompatActivity.adjustUIForAPILevel35(
+fun AppCompatActivity.prepareWindowForEdgeToEdge(
     statusBarStyle: SystemBarStyle = SystemBarStyle.auto(Color.TRANSPARENT, Color.TRANSPARENT),
     navigationBarStyle: SystemBarStyle = SystemBarStyle.auto(Color.TRANSPARENT, Color.TRANSPARENT)
 ) {

--- a/ui/src/main/java/com/nextcloud/android/common/ui/util/extensions/AppCompatActivityExtensions.kt
+++ b/ui/src/main/java/com/nextcloud/android/common/ui/util/extensions/AppCompatActivityExtensions.kt
@@ -21,13 +21,7 @@ fun AppCompatActivity.adjustUIForAPILevel35(
     statusBarStyle: SystemBarStyle = SystemBarStyle.auto(Color.TRANSPARENT, Color.TRANSPARENT),
     navigationBarStyle: SystemBarStyle = SystemBarStyle.auto(Color.TRANSPARENT, Color.TRANSPARENT)
 ) {
-    val isApiLevel35OrHigher = (Build.VERSION.SDK_INT >= 35)
-    if (!isApiLevel35OrHigher) {
-        return
-    }
-
     enableEdgeToEdge(statusBarStyle, navigationBarStyle)
-
     window.addSystemBarPaddings()
 }
 

--- a/ui/src/main/java/com/nextcloud/android/common/ui/util/extensions/WindowExtensions.kt
+++ b/ui/src/main/java/com/nextcloud/android/common/ui/util/extensions/WindowExtensions.kt
@@ -19,13 +19,15 @@ fun Window?.addSystemBarPaddings() {
     }
 
     ViewCompat.setOnApplyWindowInsetsListener(decorView) { v: View, insets: WindowInsetsCompat ->
-        val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+        val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+        val ime = insets.getInsets(WindowInsetsCompat.Type.ime())
+        val bottomInset = maxOf(systemBars.bottom, ime.bottom)
 
         v.updatePadding(
-            left = bars.left,
-            top = bars.top,
-            right = bars.right,
-            bottom = bars.bottom
+            left = systemBars.left,
+            top = systemBars.top,
+            right = systemBars.right,
+            bottom = bottomInset
         )
 
         WindowInsetsCompat.CONSUMED


### PR DESCRIPTION
### Issues

1. Users can't see the last section on the screen. 
https://github.com/nextcloud/notes-android/issues/2743
2. The status bar overlaps with the content on Android versions below 15.  https://github.com/nextcloud/notes-android/issues/2730

### Before - After

<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/1564e2e5-b24f-4264-8472-bac3098a7785" width="300" alt="Image 1"></td>
    <td><img src="https://github.com/user-attachments/assets/dd8ce277-3005-40e8-8bd9-ab8d969c3028" width="300" alt="Image 2"></td>
  </tr>
</table>

