### PR TITLE
use error for errorColor

### DIFF
--- a/ui/src/main/java/com/nextcloud/android/common/ui/theme/utils/MaterialViewThemeUtils.kt
+++ b/ui/src/main/java/com/nextcloud/android/common/ui/theme/utils/MaterialViewThemeUtils.kt
@@ -403,7 +403,7 @@ class MaterialViewThemeUtils
 
         fun colorTextInputLayout(textInputLayout: TextInputLayout) {
             withScheme(textInputLayout) { scheme ->
-                val errorColor = dynamicColor.surfaceVariant().getArgb(scheme)
+                val errorColor = dynamicColor.error().getArgb(scheme)
 
                 val errorColorStateList =
                     buildColorStateList(


### PR DESCRIPTION
Tinting was using wrong color, now it uses error, same like in:
https://github.com/nextcloud/android-common/blob/48fb6a6f0b382eadd473fd80c0baba778b33d009/ui/src/main/java/com/nextcloud/android/common/ui/theme/utils/MaterialViewThemeUtils.kt#L435

<img width="241" height="540" alt="2025-08-13-132101" src="https://github.com/user-attachments/assets/b3034f02-2003-4c21-88ff-e4a3eca88cf1" /> <img width="241" height="540" alt="2025-08-13-131856" src="https://github.com/user-attachments/assets/964f6fa9-0c7f-4616-86ae-5b83fc00ff44" />
